### PR TITLE
ADD: Markdown file to keep track of external datasets of interest

### DIFF
--- a/external_datasets.md
+++ b/external_datasets.md
@@ -1,0 +1,24 @@
+# External Datasets of Interest within the CROCUS Domain
+
+## PurpleAir (Air Quality Network)
+- [Link to Website](https://map.purpleair.com/1/i/mAQI/a10/p604800/cC5#9.11/41.7875/-87.8115)
+- Data: PM2.5 observations
+- Data method: In-situ 
+- Data type: TimeSeries
+- Cookbook Created: No 
+
+## MRLC (Multi-Resolution Land Characteristics Consortium
+- [Link to Website](https://www.mrlc.gov/viewer/)
+- Data: Gridded Land Cover Types
+- Data Method: N/A
+- Data Type: Gridded 
+- Cookbook Created: No
+
+## CHiVes (Data Collaborative and Community Mapping Application)
+- [Link to Website](https://chichives.com/map)
+- Data: Gridded Observations (including Health Metrics)
+- Data Method: N/A 
+- Data Type: Gridded
+- Cookbook Created: No
+
+


### PR DESCRIPTION
There is a request from the City-Scale thematic group to have a location that displays external datasets of interest within the CROCUS domain. 

While that may ultimately be more appropriate for official CROCUS website (https://crocus-urban.org/), this list will be helpful to:
- Keep Track of Data sources for inter-comparison with CROCUS observations
- Have a list for SULI interns to review and create cookbooks for if needed
- centralized location to combine datasets we find 